### PR TITLE
improve initialization stability, support sensor timestamps.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,6 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
-message(STATUS "CMAKE_MODULE_PATH = ${CMAKE_MODULE_PATH}")
-message(STATUS "CMAKE_SOURCE_DIR = ${CMAKE_SOURCE_DIR}")
-message(STATUS "CMAKE_PREFIX_PATH = ${CMAKE_PREFIX_PATH}")
-
 find_package(OpenCV REQUIRED)
 find_package(Spinnaker REQUIRED)
 
@@ -124,10 +120,10 @@ install(FILES nodelet_plugins.xml
 
 ## Add gtest based cpp test target and link libraries
 if (CATKIN_ENABLE_TESTING)
-  catkin_add_gtest(${PROJECT_NAME}-test 
+  catkin_add_gtest(${PROJECT_NAME}-test
     test/test_flir_adk_ethernet.cpp
   )
-  target_link_libraries(${PROJECT_NAME}-test 
+  target_link_libraries(${PROJECT_NAME}-test
     ${catkin_LIBRARIES}
     BosonCameraEthernet
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,12 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
+message(STATUS "CMAKE_MODULE_PATH = ${CMAKE_MODULE_PATH}")
+message(STATUS "CMAKE_SOURCE_DIR = ${CMAKE_SOURCE_DIR}")
+message(STATUS "CMAKE_PREFIX_PATH = ${CMAKE_PREFIX_PATH}")
+
 find_package(OpenCV REQUIRED)
+find_package(Spinnaker REQUIRED)
 
 add_message_files(
   FILES
@@ -50,7 +55,7 @@ include_directories(
   include
   ${OpenCV_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
-  /usr/include/spinnaker
+  ${Spinnaker_INCLUDE_DIRS}
 )
 
 add_executable(${PROJECT_NAME}_node
@@ -67,7 +72,7 @@ target_link_libraries(${PROJECT_NAME}_node
   ${catkin_LIBRARIES}
 )
 
-FILE(GLOB SpinLibs /usr/lib/libSpin*.so)
+FILE(GLOB SpinLibs ${Spinnaker_LIBRARIES}/libSpin*.so)
 
 add_library(BosonCameraEthernet
   src/nodelets/BaseCameraController.cpp

--- a/cmake/FindSpinnaker.cmake
+++ b/cmake/FindSpinnaker.cmake
@@ -1,13 +1,3 @@
-# @file FindSpinnaker.cmake
-#
-# Copyright 2020
-# Carnegie Robotics, LLC
-# 4501 Hatfield Street, Pittsburgh, PA 15201
-# http://www.carnegierobotics.com
-#
-# Significant history (date, user, job code, action):
-#   2020-10-08, jgeissinger@carnegierobotics.com, 2040, Created file.
-
 unset(SPINNAKER_FOUND)
 unset(SPINNAKER_INCLUDE_DIRS)
 unset(SPINNAKER_LIB)

--- a/cmake/FindSpinnaker.cmake
+++ b/cmake/FindSpinnaker.cmake
@@ -1,0 +1,34 @@
+# @file FindSpinnaker.cmake
+#
+# Copyright 2020
+# Carnegie Robotics, LLC
+# 4501 Hatfield Street, Pittsburgh, PA 15201
+# http://www.carnegierobotics.com
+#
+# Significant history (date, user, job code, action):
+#   2020-10-08, jgeissinger@carnegierobotics.com, 2040, Created file.
+
+unset(SPINNAKER_FOUND)
+unset(SPINNAKER_INCLUDE_DIRS)
+unset(SPINNAKER_LIB)
+
+find_path(SPINNAKER_DIR NAMES Spinnaker.h
+    HINTS
+        ${CMAKE_PREFIX_PATH}/include/spinnaker
+    PATH_SUFFIXES
+        spinnaker)
+
+get_filename_component(SPINNAKER_PARENT_DIR ${SPINNAKER_DIR} DIRECTORY)
+
+set(SPINNAKER_INCLUDE_DIRS "${SPINNAKER_DIR};${SPINNAKER_PARENT_DIR}")
+
+find_path(SPINNAKER_LIBRARIES NAMES libSpinnaker.so
+    HINTS
+    ${CMAKE_PREFIX_PATH}/lib)
+
+if (SPINNAKER_INCLUDE_DIRS AND SPINNAKER_LIB)
+  set(SPINNAKER_FOUND 1)
+endif (SPINNAKER_INCLUDE_DIRS AND SPINNAKER_LIB)
+
+set(Spinnaker_INCLUDE_DIRS ${SPINNAKER_INCLUDE_DIRS})
+set(Spinnaker_LIBRARIES ${SPINNAKER_LIBRARIES})

--- a/include/flir_adk_ethernet/EthernetCamera.h
+++ b/include/flir_adk_ethernet/EthernetCamera.h
@@ -121,6 +121,7 @@ class EthernetCamera
     // open camera helpers
     bool findMatchingCamera(CameraListWrapper camList, const unsigned int numCams);
     void initPixelFormat();
+    bool setPTP();
     void setBinning();
     bool setImageInfo();
     void setCameraEvents();

--- a/include/flir_adk_ethernet/EthernetCamera.h
+++ b/include/flir_adk_ethernet/EthernetCamera.h
@@ -114,7 +114,8 @@ class EthernetCamera
     // sets ROI of camera view
     bool setROI(int xOffset, int yOffset, int width, int height);
     bool setCenterROI(int width, int height);
-    bool isPtpEnabled();
+    bool isPTPEnabled();
+    bool printPTPStatus();
   private:
     PixelFormatEnums getPixelFormat(string formatStr);
 

--- a/include/flir_adk_ethernet/EthernetCamera.h
+++ b/include/flir_adk_ethernet/EthernetCamera.h
@@ -114,7 +114,7 @@ class EthernetCamera
     // sets ROI of camera view
     bool setROI(int xOffset, int yOffset, int width, int height);
     bool setCenterROI(int width, int height);
-
+    bool isPtpEnabled();
   private:
     PixelFormatEnums getPixelFormat(string formatStr);
 
@@ -166,6 +166,7 @@ class EthernetCamera
     ImageFormat _selectedFormat;
     std::string _camType;
     bool _isStreaming = false;
+    bool _ptpEnabled = false;
 };
 
 }  // namespace flir_adk_ethernet

--- a/include/flir_adk_ethernet/EthernetCamera.h
+++ b/include/flir_adk_ethernet/EthernetCamera.h
@@ -114,8 +114,10 @@ class EthernetCamera
     // sets ROI of camera view
     bool setROI(int xOffset, int yOffset, int width, int height);
     bool setCenterROI(int width, int height);
+ 
     bool isPTPEnabled();
     bool printPTPStatus();
+  
   private:
     PixelFormatEnums getPixelFormat(string formatStr);
 

--- a/launch/boson.launch
+++ b/launch/boson.launch
@@ -32,8 +32,4 @@
     <param name="camera_info_url" type="str" value="$(arg camera_info_url)"/>
   </node>
 
-  <!-- Optional: built-in image view opens window to view the streaming feed -->
-  <node name="image_view" pkg="image_view" type="image_view" respawn="false" output="screen">
-    <remap from="image" to="flir_adk/image_raw" />
-  </node>
 </launch>

--- a/launch/boson.launch
+++ b/launch/boson.launch
@@ -32,4 +32,8 @@
     <param name="camera_info_url" type="str" value="$(arg camera_info_url)"/>
   </node>
 
+  <!-- Optional: built-in image view opens window to view the streaming feed -->
+  <node name="image_view" pkg="image_view" type="image_view" respawn="false" output="screen">
+    <remap from="image" to="flir_adk/image_raw" />
+  </node>
 </launch>

--- a/launch/flir_adk.launch
+++ b/launch/flir_adk.launch
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- prefix for all topics published by this launcher -->
+  <arg name="namespace" default="flir_adk"/>
+  <!-- frame ID for identifying source when looking at image topic -->
+  <arg name="frame_id" default="boson_camera"/>
+  <!-- camera type notifies the application to get the first camera whose
+  name contains "boson" -->
+  <arg name="camera_type" default="boson" />
+    
+  <!-- topic frame rate - limited by the max frame rate of the camera -->
+  <arg name="frame_rate" default="60.0"/>
+
+  <!-- valid values are MONO_8 and MONO_16 for boson -->
+  <arg name="video_format" default="MONO_8"/>
+
+  <!-- location of the camera calibration file -->
+  <arg name="camera_info_url" default="package://flir_adk_ethernet/example_calibrations/BlackFlyS.yaml"/>
+
+  <!-- node launcher -->
+  <node pkg="flir_adk_ethernet" 
+        type="flir_adk_ethernet_node" 
+        name="flir_adk_ethernet_node" 
+        ns="$(arg namespace)"
+        output="screen">
+    <remap from="image" to="image_raw" />
+
+    <param name="frame_id" type="str" value="$(arg frame_id)"/>
+    <param name="camera_type" type="str" value="$(arg camera_type)"/>
+    <param name="frame_rate" type="double" value="$(arg frame_rate)"/>
+    <param name="video_format" type="str" value="$(arg video_format)"/>
+    <param name="camera_info_url" type="str" value="$(arg camera_info_url)"/>
+  </node>
+
+</launch>

--- a/spinnaker_wrappers/CameraWrapper.cpp
+++ b/spinnaker_wrappers/CameraWrapper.cpp
@@ -22,6 +22,11 @@ void CameraWrapper::Init() {
     _cam->Init();
 }
 
+
+bool CameraWrapper::IsInitialized() {
+    _cam->IsInitialized();
+}
+
 bool CameraWrapper::IsValid() {
     return _cam->IsValid();
 }

--- a/spinnaker_wrappers/CameraWrapper.h
+++ b/spinnaker_wrappers/CameraWrapper.h
@@ -25,6 +25,7 @@ class CameraWrapper {
     CameraWrapper(const CameraWrapper& wrapper);
     virtual ~CameraWrapper();
     virtual void Init();
+    virtual bool IsInitialized();
     virtual bool IsValid();
     virtual INodeMap& GetNodeMap();
     virtual INodeMap& GetTLDeviceNodeMap();

--- a/src/flir_adk_ethernet/EthernetCamera.cpp
+++ b/src/flir_adk_ethernet/EthernetCamera.cpp
@@ -60,7 +60,15 @@ bool EthernetCamera::openCamera()
         ROS_ERROR("flir_adk_ethernet - ERROR : OPEN. No device matches ip_addr: %s", _ipAddr.c_str());
         return false;
     }
-    _pCam->Init();
+
+    try {
+        _pCam->Init();
+    }
+    catch(Spinnaker::Exception e) {
+        ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
+        return false;
+    }
+
     initPixelFormat();
 
     if(!setPTP()) {
@@ -84,7 +92,7 @@ bool EthernetCamera::openCamera()
 
     initOpenCVBuffers();
     setCameraInfo();
-
+    std::cout << "here" << std::endl;
     return true;
 } 
 
@@ -332,7 +340,7 @@ void EthernetCamera::setCameraInfo() {
 }
 
 bool EthernetCamera::closeCamera() {
-    if(_pCam) {
+    if(_pCam && _pCam->IsInitialized()) {
         unsetCameraEvents();
         stopCapture();
         _pCam->DeInit();

--- a/src/flir_adk_ethernet/EthernetCamera.cpp
+++ b/src/flir_adk_ethernet/EthernetCamera.cpp
@@ -64,7 +64,7 @@ bool EthernetCamera::openCamera()
     try {
         _pCam->Init();
     }
-    catch(const Spinnaker::Exception e) {
+    catch(const Spinnaker::Exception & e) {
         ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
         return false;
     }
@@ -92,7 +92,7 @@ bool EthernetCamera::openCamera()
 
     initOpenCVBuffers();
     setCameraInfo();
-    
+
     return true;
 } 
 
@@ -158,7 +158,7 @@ bool EthernetCamera::setPTP() {
         ROS_INFO("flir_adk_ethernet - INFO : PTP status flag: %ld", ptpStatus->GetIntValue());
         return true;
     }
-    catch(const Spinnaker::Exception e) {
+    catch(const Spinnaker::Exception & e) {
         ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
         return false;
     }
@@ -176,7 +176,7 @@ bool EthernetCamera::printPTPStatus() {
         ROS_INFO("flir_adk_ethernet - INFO : PTP status flag: %ld", ptpStatus->GetIntValue());
         return true;
     }   
-    catch(const Spinnaker::Exception e) {
+    catch(const Spinnaker::Exception & e) {
         ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
         return false;
     }  
@@ -188,7 +188,7 @@ bool EthernetCamera::setImageInfo() {
         setROI(_xOffset, _yOffset, _width, _height);
 
         return true;
-    } catch(const Spinnaker::Exception e) {
+    } catch(const Spinnaker::Exception & e) {
         ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
         return false;
     }
@@ -223,7 +223,7 @@ void EthernetCamera::initPixelFormat() {
         CEnumerationPtr pixelFormatNode = nodeMap.GetNode("PixelFormat");
 
         pixelFormatNode->SetIntValue(_selectedFormat.getValue(pixelFormatNode));
-    } catch(const Spinnaker::Exception e) {
+    } catch(const Spinnaker::Exception & e) {
         ROS_INFO("flir_adk_ethernet - ERROR : Unable to set pixel format to: %s", _selectedFormat.toString().c_str());
     }
 }
@@ -302,7 +302,7 @@ bool EthernetCamera::setROI(int xOffset, int yOffset, int width, int height) {
         ROS_INFO("flir_adk_ethernet - INFO : Camera info - Width: %d, Height: %d, X Offset: %d, Y Offset: %d",
             _width, _height, _xOffset, _yOffset);
         return true;
-    } catch (const Spinnaker::Exception e) {
+    } catch (const Spinnaker::Exception & e) {
         ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
 
         widthNode->SetValue(8);
@@ -385,7 +385,7 @@ bool EthernetCamera::closeCamera() {
 void EthernetCamera::unsetCameraEvents() {
     try {
         _pCam->UnregisterEvent(*_imageHandler);
-    } catch(const Spinnaker::Exception e) {
+    } catch(const Spinnaker::Exception &) {
         // if there's an error - the event is already unregistered, 
         // or the camera is invalid (no need to unset)
     }
@@ -513,7 +513,7 @@ bool EthernetCamera::setNodeValue(std::string nodeName, std::string value) {
                 break;
             }
         }
-    } catch(const Spinnaker::Exception e) {
+    } catch(const Spinnaker::Exception & e) {
         ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
     }
     
@@ -571,7 +571,7 @@ void EthernetCamera::stopCapture() {
     try {
         _isStreaming = false;
         _pCam->EndAcquisition();
-    } catch(const Spinnaker::Exception e) {
+    } catch(const Spinnaker::Exception & e) {
         ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
     }
 }

--- a/src/flir_adk_ethernet/EthernetCamera.cpp
+++ b/src/flir_adk_ethernet/EthernetCamera.cpp
@@ -105,6 +105,12 @@ bool EthernetCamera::findMatchingCamera(CameraListWrapper camList, const unsigne
         CameraWrapper cam = camList.GetByIndex(i);
         INodeMap &nodeMapTLDevice = cam.GetTLDeviceNodeMap();
 
+        CBooleanPtr wrongSubnet = nodeMapTLDevice.GetNode("GevDeviceIsWrongSubnet");
+        if (wrongSubnet->GetValue())
+        {
+            continue;
+        }
+
         if((!_ipAddr.empty() && ipMatches(_ipAddr, nodeMapTLDevice)) ||
            (_ipAddr.empty() && camTypeMatches(_camType, nodeMapTLDevice)))
         {

--- a/src/flir_adk_ethernet/EthernetCamera.cpp
+++ b/src/flir_adk_ethernet/EthernetCamera.cpp
@@ -63,6 +63,11 @@ bool EthernetCamera::openCamera()
     _pCam->Init();
     initPixelFormat();
 
+    if(!setPTP()) {
+        ROS_ERROR("flir_adk_ethernet - ERROR : SET PTP. Cannot set ptp for timesync.");
+        return false;
+    }
+
     if(!setImageInfo()) {
         ROS_ERROR("flir_adk_ethernet - ERROR : GET_CONFIGURATION. Cannot get image for setting dimensions");
         return false;
@@ -121,6 +126,23 @@ bool EthernetCamera::camTypeMatches(string camType, INodeMap& nodeMapTLDevice) {
     }
     
     return false;
+}
+
+bool EthernetCamera::setPTP() {
+    try {
+        INodeMap &nodeMap = _pCam->GetNodeMap();
+        CBooleanPtr ptpEnableNode = nodeMap.GetNode("GevIEEE1588");
+        CEnumerationPtr ptpModeNode = nodeMap.GetNode("GevIEEE1588Mode");
+
+        ptpEnableNode->SetValue(true);
+        ptpModeNode->SetIntValue(Spinnaker::GevIEEE1588Mode_SlaveOnly);
+
+        return true;
+    }
+    catch(Spinnaker::Exception e) {
+        ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
+        return false;
+    }
 }
 
 bool EthernetCamera::setImageInfo() {

--- a/src/flir_adk_ethernet/EthernetCamera.cpp
+++ b/src/flir_adk_ethernet/EthernetCamera.cpp
@@ -107,7 +107,7 @@ bool EthernetCamera::findMatchingCamera(CameraListWrapper camList, const unsigne
 
         CBooleanPtr wrongSubnet = nodeMapTLDevice.GetNode("GevDeviceIsWrongSubnet");
         if (wrongSubnet->GetValue()) {
-            ROS_INFO("Skipping wrong subnet.");
+            ROS_INFO("flir_adk_ethernet - INFO : Skipping wrong subnet.");
             continue;
         }
 
@@ -115,7 +115,7 @@ bool EthernetCamera::findMatchingCamera(CameraListWrapper camList, const unsigne
            (_ipAddr.empty() && camTypeMatches(_camType, nodeMapTLDevice)))
         {
             CStringPtr modelName = nodeMapTLDevice.GetNode("DeviceModelName");
-            ROS_INFO("Found matching camera %s", modelName->ToString().c_str());
+            ROS_INFO("flir_adk_ethernet - INFO : Found matching camera %s", modelName->ToString().c_str());
             _pCam = std::make_shared<CameraWrapper>(cam);
             return true;
         }
@@ -153,9 +153,9 @@ bool EthernetCamera::setPTP() {
         ptpMode->SetIntValue(Spinnaker::GevIEEE1588Mode_SlaveOnly);
         _ptpEnabled = true;
         
-        ROS_INFO("flir_adk_ethernet - PTP enabled flag: %d", ptpEnable->GetValue());
-        ROS_INFO("flir_adk_ethernet - Set PTP to mode %d", ptpMode->GetIntValue());
-        ROS_INFO("flir_adk_ethernet - PTP status flag: %d", ptpStatus->GetIntValue());
+        ROS_INFO("flir_adk_ethernet - INFO : PTP enabled flag: %d", ptpEnable->GetValue());
+        ROS_INFO("flir_adk_ethernet - INFO : Set PTP to mode %d", ptpMode->GetIntValue());
+        ROS_INFO("flir_adk_ethernet - INFO : PTP status flag: %d", ptpStatus->GetIntValue());
         return true;
     }
     catch(const Spinnaker::Exception e) {
@@ -171,9 +171,9 @@ bool EthernetCamera::printPTPStatus() {
         CEnumerationPtr ptpMode = nodeMap.GetNode("GevIEEE1588Mode");
         CEnumerationPtr ptpStatus = nodeMap.GetNode("GevIEEE1588Status");
 
-        ROS_INFO("flir_adk_ethernet - PTP enabled flag: %d", ptpEnable->GetValue());
-        ROS_INFO("flir_adk_ethernet - Set PTP to mode %d", ptpMode->GetIntValue());
-        ROS_INFO("flir_adk_ethernet - PTP status flag: %d", ptpStatus->GetIntValue());
+        ROS_INFO("flir_adk_ethernet - INFO : PTP enabled flag: %d", ptpEnable->GetValue());
+        ROS_INFO("flir_adk_ethernet - INFO : Set PTP to mode %d", ptpMode->GetIntValue());
+        ROS_INFO("flir_adk_ethernet - INFO : PTP status flag: %d", ptpStatus->GetIntValue());
         return true;
     }   
     catch(const Spinnaker::Exception e) {
@@ -224,7 +224,7 @@ void EthernetCamera::initPixelFormat() {
 
         pixelFormatNode->SetIntValue(_selectedFormat.getValue(pixelFormatNode));
     } catch(const Spinnaker::Exception e) {
-        ROS_INFO("Unable to set pixel format to: %s", _selectedFormat.toString().c_str());
+        ROS_INFO("flir_adk_ethernet - ERROR : Unable to set pixel format to: %s", _selectedFormat.toString().c_str());
     }
 }
 
@@ -299,7 +299,7 @@ bool EthernetCamera::setROI(int xOffset, int yOffset, int width, int height) {
             resetBuffer();
         }
 
-        ROS_INFO("Camera info - Width: %d, Height: %d, X Offset: %d, Y Offset: %d",
+        ROS_INFO("flir_adk_ethernet - INFO : Camera info - Width: %d, Height: %d, X Offset: %d, Y Offset: %d",
             _width, _height, _xOffset, _yOffset);
         return true;
     } catch (const Spinnaker::Exception e) {
@@ -330,7 +330,7 @@ bool EthernetCamera::setImageAcquisition() {
     CEnumerationPtr ptrAcquisitionMode = nodeMap.GetNode("AcquisitionMode");
     if (!IsAvailable(ptrAcquisitionMode) || !IsWritable(ptrAcquisitionMode)) 
     {
-        ROS_ERROR("Unable to set acquisition mode. Aborting...");
+        ROS_ERROR("flir_adk_ethernet - INFO : Unable to set acquisition mode. Aborting...");
         return false;
     }
 
@@ -338,7 +338,7 @@ bool EthernetCamera::setImageAcquisition() {
     CEnumEntryPtr ptrAcquisitionModeContinuous = ptrAcquisitionMode->GetEntryByName("Continuous");
     if (!IsAvailable(ptrAcquisitionModeContinuous) || !IsReadable(ptrAcquisitionModeContinuous))
     {
-        ROS_ERROR("Unable to set acquisition mode to continuous (entry retrieval). Aborting...");
+        ROS_ERROR("flir_adk_ethernet - INFO : Unable to set acquisition mode to continuous (entry retrieval). Aborting...");
         return false;
     }
 
@@ -348,7 +348,7 @@ bool EthernetCamera::setImageAcquisition() {
     // Set integer value from entry node as new value of enumeration node
     ptrAcquisitionMode->SetIntValue(acquisitionModeContinuous);
 
-    ROS_INFO("Acquisition mode set to continuous...");
+    ROS_INFO("flir_adk_ethernet - INFO : Acquisition mode set to continuous...");
     
     startCapture();
 
@@ -368,7 +368,7 @@ void EthernetCamera::setCameraInfo() {
     if (_cameraInfo->validateURL(_cameraInfoPath)) {
         _cameraInfo->loadCameraInfo(_cameraInfoPath);
     } else {
-        ROS_INFO("flir_adk_ethernet - camera_info_url could not be validated. Publishing with unconfigured camera.");
+        ROS_INFO("flir_adk_ethernet - INFO : camera_info_url could not be validated. Publishing with unconfigured camera.");
     }
 }
 

--- a/src/flir_adk_ethernet/EthernetCamera.cpp
+++ b/src/flir_adk_ethernet/EthernetCamera.cpp
@@ -92,6 +92,7 @@ bool EthernetCamera::openCamera()
 
     initOpenCVBuffers();
     setCameraInfo();
+    
     return true;
 } 
 
@@ -143,18 +144,41 @@ bool EthernetCamera::camTypeMatches(string camType, INodeMap& nodeMapTLDevice) {
 bool EthernetCamera::setPTP() {
     try {
         INodeMap &nodeMap = _pCam->GetNodeMap();
-        CBooleanPtr ptpEnableNode = nodeMap.GetNode("GevIEEE1588");
-        CEnumerationPtr ptpModeNode = nodeMap.GetNode("GevIEEE1588Mode");
+        CBooleanPtr ptpEnable = nodeMap.GetNode("GevIEEE1588");
+        CEnumerationPtr ptpMode = nodeMap.GetNode("GevIEEE1588Mode");
+        CEnumerationPtr ptpStatus = nodeMap.GetNode("GevIEEE1588Status");
 
-        ptpEnableNode->SetValue(true);
-        ptpModeNode->SetIntValue(Spinnaker::GevIEEE1588Mode_SlaveOnly);
+        ptpEnable->SetValue(true);
+        ptpMode->SetIntValue(Spinnaker::GevIEEE1588Mode_SlaveOnly);
         _ptpEnabled = true;
+        
+        ROS_INFO("flir_adk_ethernet - PTP enabled flag: %d", ptpEnable->GetValue());
+        ROS_INFO("flir_adk_ethernet - Set PTP to mode %d", ptpMode->GetIntValue());
+        ROS_INFO("flir_adk_ethernet - PTP status flag: %d", ptpStatus->GetIntValue());
         return true;
     }
     catch(const Spinnaker::Exception e) {
         ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
         return false;
     }
+}
+
+bool EthernetCamera::printPTPStatus() {
+    try {
+        INodeMap &nodeMap = _pCam->GetNodeMap();
+        CBooleanPtr ptpEnable = nodeMap.GetNode("GevIEEE1588");
+        CEnumerationPtr ptpMode = nodeMap.GetNode("GevIEEE1588Mode");
+        CEnumerationPtr ptpStatus = nodeMap.GetNode("GevIEEE1588Status");
+
+        ROS_INFO("flir_adk_ethernet - PTP enabled flag: %d", ptpEnable->GetValue());
+        ROS_INFO("flir_adk_ethernet - Set PTP to mode %d", ptpMode->GetIntValue());
+        ROS_INFO("flir_adk_ethernet - PTP status flag: %d", ptpStatus->GetIntValue());
+        return true;
+    }   
+    catch(const Spinnaker::Exception e) {
+        ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
+        return false;
+    }  
 }
 
 bool EthernetCamera::setImageInfo() {
@@ -222,7 +246,7 @@ bool EthernetCamera::setCenterROI(int width, int height) {
     return setROI(xOffset, yOffset, width, height);
 }
 
-bool EthernetCamera::isPtpEnabled() {
+bool EthernetCamera::isPTPEnabled() {
     return _ptpEnabled;
 }
 

--- a/src/flir_adk_ethernet/EthernetCamera.cpp
+++ b/src/flir_adk_ethernet/EthernetCamera.cpp
@@ -107,6 +107,7 @@ bool EthernetCamera::findMatchingCamera(CameraListWrapper camList, const unsigne
 
         CBooleanPtr wrongSubnet = nodeMapTLDevice.GetNode("GevDeviceIsWrongSubnet");
         if (wrongSubnet->GetValue()) {
+            ROS_INFO("Skipping wrong subnet.");
             continue;
         }
 

--- a/src/flir_adk_ethernet/EthernetCamera.cpp
+++ b/src/flir_adk_ethernet/EthernetCamera.cpp
@@ -64,7 +64,7 @@ bool EthernetCamera::openCamera()
     try {
         _pCam->Init();
     }
-    catch(Spinnaker::Exception e) {
+    catch(const Spinnaker::Exception e) {
         ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
         return false;
     }
@@ -92,7 +92,6 @@ bool EthernetCamera::openCamera()
 
     initOpenCVBuffers();
     setCameraInfo();
-    std::cout << "here" << std::endl;
     return true;
 } 
 
@@ -106,8 +105,7 @@ bool EthernetCamera::findMatchingCamera(CameraListWrapper camList, const unsigne
         INodeMap &nodeMapTLDevice = cam.GetTLDeviceNodeMap();
 
         CBooleanPtr wrongSubnet = nodeMapTLDevice.GetNode("GevDeviceIsWrongSubnet");
-        if (wrongSubnet->GetValue())
-        {
+        if (wrongSubnet->GetValue()) {
             continue;
         }
 
@@ -150,10 +148,10 @@ bool EthernetCamera::setPTP() {
 
         ptpEnableNode->SetValue(true);
         ptpModeNode->SetIntValue(Spinnaker::GevIEEE1588Mode_SlaveOnly);
-
+        _ptpEnabled = true;
         return true;
     }
-    catch(Spinnaker::Exception e) {
+    catch(const Spinnaker::Exception e) {
         ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
         return false;
     }
@@ -165,7 +163,7 @@ bool EthernetCamera::setImageInfo() {
         setROI(_xOffset, _yOffset, _width, _height);
 
         return true;
-    } catch(Spinnaker::Exception e) {
+    } catch(const Spinnaker::Exception e) {
         ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
         return false;
     }
@@ -200,7 +198,7 @@ void EthernetCamera::initPixelFormat() {
         CEnumerationPtr pixelFormatNode = nodeMap.GetNode("PixelFormat");
 
         pixelFormatNode->SetIntValue(_selectedFormat.getValue(pixelFormatNode));
-    } catch(Spinnaker::Exception e) {
+    } catch(const Spinnaker::Exception e) {
         ROS_INFO("Unable to set pixel format to: %s", _selectedFormat.toString().c_str());
     }
 }
@@ -222,6 +220,10 @@ bool EthernetCamera::setCenterROI(int width, int height) {
     int xOffset = max(0, (maxWidth - width) / 2);
     int yOffset = max(0, (maxHeight - height) / 2);
     return setROI(xOffset, yOffset, width, height);
+}
+
+bool EthernetCamera::isPtpEnabled() {
+    return _ptpEnabled;
 }
 
 bool EthernetCamera::setROI(int xOffset, int yOffset, int width, int height) {
@@ -275,7 +277,7 @@ bool EthernetCamera::setROI(int xOffset, int yOffset, int width, int height) {
         ROS_INFO("Camera info - Width: %d, Height: %d, X Offset: %d, Y Offset: %d",
             _width, _height, _xOffset, _yOffset);
         return true;
-    } catch (Spinnaker::Exception e) {
+    } catch (const Spinnaker::Exception e) {
         ROS_ERROR(e.what());
 
         widthNode->SetValue(8);
@@ -358,7 +360,7 @@ bool EthernetCamera::closeCamera() {
 void EthernetCamera::unsetCameraEvents() {
     try {
         _pCam->UnregisterEvent(*_imageHandler);
-    } catch(Spinnaker::Exception e) {
+    } catch(const Spinnaker::Exception e) {
         // if there's an error - the event is already unregistered, 
         // or the camera is invalid (no need to unset)
     }
@@ -486,7 +488,7 @@ bool EthernetCamera::setNodeValue(std::string nodeName, std::string value) {
                 break;
             }
         }
-    } catch(Spinnaker::Exception e) {
+    } catch(const Spinnaker::Exception e) {
         ROS_ERROR(e.what());
     }
     
@@ -544,7 +546,7 @@ void EthernetCamera::stopCapture() {
     try {
         _isStreaming = false;
         _pCam->EndAcquisition();
-    } catch(Spinnaker::Exception e) {
+    } catch(const Spinnaker::Exception e) {
         ROS_ERROR(e.what());
     }
 }

--- a/src/flir_adk_ethernet/EthernetCamera.cpp
+++ b/src/flir_adk_ethernet/EthernetCamera.cpp
@@ -154,8 +154,8 @@ bool EthernetCamera::setPTP() {
         _ptpEnabled = true;
         
         ROS_INFO("flir_adk_ethernet - INFO : PTP enabled flag: %d", ptpEnable->GetValue());
-        ROS_INFO("flir_adk_ethernet - INFO : Set PTP to mode %d", ptpMode->GetIntValue());
-        ROS_INFO("flir_adk_ethernet - INFO : PTP status flag: %d", ptpStatus->GetIntValue());
+        ROS_INFO("flir_adk_ethernet - INFO : Set PTP to mode %ld", ptpMode->GetIntValue());
+        ROS_INFO("flir_adk_ethernet - INFO : PTP status flag: %ld", ptpStatus->GetIntValue());
         return true;
     }
     catch(const Spinnaker::Exception e) {
@@ -172,8 +172,8 @@ bool EthernetCamera::printPTPStatus() {
         CEnumerationPtr ptpStatus = nodeMap.GetNode("GevIEEE1588Status");
 
         ROS_INFO("flir_adk_ethernet - INFO : PTP enabled flag: %d", ptpEnable->GetValue());
-        ROS_INFO("flir_adk_ethernet - INFO : Set PTP to mode %d", ptpMode->GetIntValue());
-        ROS_INFO("flir_adk_ethernet - INFO : PTP status flag: %d", ptpStatus->GetIntValue());
+        ROS_INFO("flir_adk_ethernet - INFO : Set PTP to mode %ld", ptpMode->GetIntValue());
+        ROS_INFO("flir_adk_ethernet - INFO : PTP status flag: %ld", ptpStatus->GetIntValue());
         return true;
     }   
     catch(const Spinnaker::Exception e) {
@@ -303,7 +303,7 @@ bool EthernetCamera::setROI(int xOffset, int yOffset, int width, int height) {
             _width, _height, _xOffset, _yOffset);
         return true;
     } catch (const Spinnaker::Exception e) {
-        ROS_ERROR(e.what());
+        ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
 
         widthNode->SetValue(8);
         heightNode->SetValue(8);
@@ -514,7 +514,7 @@ bool EthernetCamera::setNodeValue(std::string nodeName, std::string value) {
             }
         }
     } catch(const Spinnaker::Exception e) {
-        ROS_ERROR(e.what());
+        ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
     }
     
     startCapture();
@@ -572,7 +572,7 @@ void EthernetCamera::stopCapture() {
         _isStreaming = false;
         _pCam->EndAcquisition();
     } catch(const Spinnaker::Exception e) {
-        ROS_ERROR(e.what());
+        ROS_ERROR("flir_adk_ethernet - ERROR : %s", e.what());
     }
 }
 

--- a/src/nodelets/CameraController.cpp
+++ b/src/nodelets/CameraController.cpp
@@ -33,6 +33,12 @@ void CameraController::setupFramePublish() {
 
 void CameraController::captureAndPublish(const ros::TimerEvent &evt)
 {
+    if (!_camera->isPtpEnabled())
+    {
+        publishImage(ros::Time::now());
+        return;
+    }
+
     uint64_t nsecs = fmod(_camera->getActualTimestamp(), 1e9);
     uint64_t secs = _camera->getActualTimestamp() / 1e9;
     ros::Time stamp(secs, nsecs);

--- a/src/nodelets/CameraController.cpp
+++ b/src/nodelets/CameraController.cpp
@@ -4,6 +4,8 @@
 /*  All rights reserved.                                                      */
 /*                                                                            */
 /******************************************************************************/
+#include <math.h>
+
 #include <pluginlib/class_list_macros.h>
 #include <fstream>
 #include "flir_adk_ethernet/CameraController.h"
@@ -31,5 +33,8 @@ void CameraController::setupFramePublish() {
 
 void CameraController::captureAndPublish(const ros::TimerEvent &evt)
 {
-    publishImage(ros::Time::now());
+    uint64_t nsecs = fmod(_camera->getActualTimestamp(), 1e9);
+    uint64_t secs = _camera->getActualTimestamp() / 1e9;
+    ros::Time stamp(secs, nsecs);
+    publishImage(stamp);
 }

--- a/src/nodelets/CameraController.cpp
+++ b/src/nodelets/CameraController.cpp
@@ -33,7 +33,7 @@ void CameraController::setupFramePublish() {
 
 void CameraController::captureAndPublish(const ros::TimerEvent &evt)
 {
-    if (!_camera->isPtpEnabled())
+    if (!_camera->isPTPEnabled())
     {
         publishImage(ros::Time::now());
         return;


### PR DESCRIPTION
Summary: Modify flir_adk_ethernet to fix segfaults, properly find subnet, and publish correct timestamp. Also, enabled PTP timestamping for timesync.

Test plan: Tested changes locally with FLIR ADK and logged images.